### PR TITLE
feat: create dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends iputils-ping \
+    gcc \
+    libpq-dev \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY Pipfile Pipfile.lock /app/
+
+ENV PIPENV_CUSTOM_VENV_NAME=ORCHESTRATOR
+RUN pip install --no-cache-dir pipenv && pipenv install --deploy --ignore-pipfile
+
+COPY . /app
+
+# uncomment when this issue is resolved:
+# https://github.com/CPNV-ES-BI1-RIA2-ETL-INTERNAL-SOURCE/ORCHESTRATOR/issues/5#issue-2807636570
+#RUN pipenv run pytest
+
+EXPOSE 8000
+
+CMD ["pipenv", "run", "fastapi", "run"]


### PR DESCRIPTION
This pull request includes significant changes to the `Dockerfile` to set up a Python environment for the application. The most important changes include setting up the base image, installing necessary dependencies, configuring the environment, and setting up the command to run the application.

Setup and dependencies:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R24): Set the base image to `python:3.13-slim` and created a working directory `/app`.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R24): Installed necessary packages such as `iputils-ping`, `gcc`, `libpq-dev`, and `build-essential`.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R24): Copied `Pipfile` and `Pipfile.lock` to the working directory and installed dependencies using `pipenv`.

Environment configuration and application startup:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R24): Configured the custom virtual environment name `ORCHESTRATOR` and exposed port 8000.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R24): Set the command to run the application using `pipenv` and `fastapi`.